### PR TITLE
quick fix about the serve file

### DIFF
--- a/modelci/hub/deployer/pytorch/pytorch_serve.py
+++ b/modelci/hub/deployer/pytorch/pytorch_serve.py
@@ -12,7 +12,7 @@ import uvicorn
 from PIL import Image
 from fastapi import FastAPI
 from fastapi import File
-from proto import service_pb2_grpc, service_pb2
+import service_pb2_grpc, service_pb2
 
 # get path
 model_base_dir = Path('/model') / sys.argv[1]


### PR DESCRIPTION
原来的 code 在 docker 里面跑 pytorch_serve.py 的时候找不到生成的 proto 相关 code，好像生成到 当前目录下了，改了这个 build 之后就没问题。