### PR TITLE
[MRG][fix] Fixed the CUDA Device Re-Mapping Issue

### DIFF
--- a/modelci/hub/deployer/pytorch/pytorch_serve.py
+++ b/modelci/hub/deployer/pytorch/pytorch_serve.py
@@ -26,7 +26,7 @@ class ServingEngine(object):
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
         # load the latest version of a TorchScript model
-        self.model = torch.jit.load(str(max(model_dir))).to(self.device)
+        self.model = torch.jit.load(str(max(model_dir)), map_location=self.device)
         self.model.eval()
 
     def batch_predict(self, inputs: torch.Tensor):

--- a/modelci/hub/deployer/pytorch/pytorch_serve.py
+++ b/modelci/hub/deployer/pytorch/pytorch_serve.py
@@ -33,7 +33,10 @@ class ServingEngine(object):
         inputs = inputs.to(self.device)
         outputs = self.model(inputs)
 
-        return outputs.cpu().detach().tolist()
+        if isinstance(outputs, tuple):
+            return outputs[0].cpu().detach().tolist()
+        else:
+            return outputs.cpu().detach().tolist()
 
 
 class PredictServicer(service_pb2_grpc.PredictServicer):


### PR DESCRIPTION
If the PyTorch model was loaded using the jit, it will keeps the original mapping location, we need to remap so that the model can adapt to the new deployment device. 

This issue resolves https://github.com/huangyz0918/bmk/issues/17, for more information, please have a look.

The change was tested with success in both BERT series models serving and the ResNet50 we used before. @YuanmingLeee remember to rebuild the `mlmodelci/pytorch-serving` docker image once the PR is merged.