### PR TITLE
Add modelci cli __start__ func and add contribute guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ conda env create -f environment.yml
 
 # install PyTorch with specific CUDA version
 conda install pytorch torchvision cudatoolkit=<YOUR_CUDA_VERSION> -c pytorch
+# or install without CUDA available
+# conda install pytorch torchvision torchaudio cpuonly -c pytorch
 pip install tensorflow-serving-api
 ```
 
@@ -59,3 +61,98 @@ tests.
 
 We have some static checks when you filing a PR or pushing commits to the project, please make sure you can pass all the tests and make sure the coding style meets our requirements.
 
+## Contribution guide
+
+### 1. Clone your fork and configure the upstream
+
+Firstly, you have to fork this repo: <https://github.com/cap-ntu/ML-Model-CI> and create a local clone of this fork
+
+```shell
+git clone git@github.com:<YOUR-USERNAME>/ML-Model-CI.git
+```
+
+Then add the original repository as upstream
+
+```shell
+cd ML-Model-CI
+git remote add upstream git@github.com:cap-ntu/ML-Model-CI.git
+```
+
+you can use the following command to verify that the remote is set
+
+```shell
+git remote -v
+```
+
+### 2. Sync the changes of the original repo
+
+This is a must before you make any changes to your fork, or conflict may happen.
+
+```shell
+git fetch upstream
+git checkout master
+git merge upstream/master
+git push origin master
+```
+
+or you can automate simplify this work by the following command
+
+```shell
+git branch --set-upstream-to=upstream/master master
+git config --local remote.pushDefault origin
+```
+
+and then the workflow becomes:
+
+```shell
+git checkout master
+git fetch
+git merge
+git push
+```
+
+### 3. Select (or open) an issue and create a new branch
+
+Before you may any pull request, please correlate your branch with at least one [existing opened issue](https://github.com/cap-ntu/ML-Model-CI/issues) or open one with appropriate labels.
+
+Then you can create a new branch, make sure the branch name is descriptive.
+
+```shell
+git checkout -b <NEW-BRANCH-NAME>
+```
+
+### 4. Make the change and commit
+
+After making the necessary change, you can commit it to your local repository. There is a general rule for making a commit:
+
+> Commits should be logical, atomic units of change
+
+```shell
+git add -A
+git commit -m "<COMMIT-MESSAGE>"
+```
+
+### 5. Open a pull request
+
+Then push the commit to your Github fork
+
+```shell
+git push -u origin <NEW-BRANCH-NAME>
+```
+
+You can make a pull request now, make sure to link the relevant issue in your pull request description.
+Here are relevant docs which may help:
+
+<https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue>
+
+If your branch is out of date during the process, it cannot be merge automatically and you should fix your branch by merging the target branch into your branch.
+
+### 6. Delete the branch
+
+Once your pull request is merged into the original repository, you should delete the new branch and push the deletion to your fork
+
+```shell
+git branch -d <NEW-BRANCH-NAME>
+git push -u origin master
+git push --delete origin
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,12 +11,6 @@ To contribute to the ModelCI, you need to setup the developing environment first
 ```shell script
 # create environment
 conda env create -f environment.yml
-
-# install PyTorch with specific CUDA version
-conda install pytorch torchvision cudatoolkit=<YOUR_CUDA_VERSION> -c pytorch
-# or install without CUDA available
-# conda install pytorch torchvision torchaudio cpuonly -c pytorch
-pip install tensorflow-serving-api
 ```
 
 ### Install Service

--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ clear start, we present the whole pipeline step by step as follows.
 Once you have installed, start ModelCI service by:
 ```python
 import modelci.cli
-
+# without GPU support
 modelci.cli.start()
+# with GPU avaliable
+modelci.cli.__start__(gpu=True)
 ```
 
 ### Register a Model

--- a/modelci/cli/__init__.py
+++ b/modelci/cli/__init__.py
@@ -22,14 +22,18 @@ def cli():
     pass
 
 
-@cli.command()
-@click.option('--gpu', default=False, type=click.BOOL, is_flag=True)
-def start(gpu=False):
+def __start__(gpu=False):
     """Start the ModelCI service."""
     container_conn = DockerContainerManager(enable_gpu=gpu)
     if not container_conn.start():
         container_conn.connect()
     app_start()
+
+
+@cli.command()
+@click.option('--gpu', default=False, type=click.BOOL, is_flag=True)
+def start(gpu=False):
+    __start__(gpu)
 
 
 @cli.command()


### PR DESCRIPTION
<!-- 
Closed which issue, if no, open one.
-->

Closes #153 #152 

<!-- 
Thank you for contributing to ML-Model_CI!
-->

#### What has been done to verify that this works as intended?

Add a __start__ function based on this  StackOverflow question:  https://stackoverflow.com/questions/37041126/unexpected-keyword-argument-in-python-click, so we can start modelci with GPU enable use following script:

```python
import modelci.cli
# with GPU avaliable
modelci.cli.__start__(gpu=True)
```

#### Why is this the best possible solution? Were any other approaches considered?

It's provide a way to start modelci with GPU support via python script

start with GPU support via command line
```shell
source scripts/setup_env.sh
python modelci/cli/__init__.py start --gpu
```

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to documentation?
Yes
#### Before submitting this PR, please make sure you have:

- [ x ] run `python -m pytest tests/` and confirmed all checks still pass.
- [ x ] verified that any code or assets from external sources are properly credited.
