### PR TITLE
convert functions and unit test

### DIFF
--- a/modelci/hub/converter/to_onnx.py
+++ b/modelci/hub/converter/to_onnx.py
@@ -18,10 +18,14 @@ from pathlib import Path
 from typing import Iterable, List, Optional, Callable
 
 import onnx
+import subprocess
 import onnxmltools as onnxmltools
+import os
 import torch
 import torch.jit
 import torch.onnx
+import tempfile
+import tensorflow as tf
 from modelci.utils import Logger
 
 from modelci.types.type_conversion import model_data_type_to_torch, model_data_type_to_onnx
@@ -36,7 +40,7 @@ class ONNXConverter(object):
     """Convert model to ONNX format."""
 
     DEFAULT_OPSET = 10
-    supported_framework = ["pytorch", "keras", "sklearn", "xgboost", "lightgbm"]
+    supported_framework = ["pytorch", "keras", "sklearn", "xgboost", "lightgbm","tensorflow"]
 
     class _Wrapper(object):
         @staticmethod
@@ -167,8 +171,40 @@ class ONNXConverter(object):
             model: keras.models.Model,
             opset: int = DEFAULT_OPSET,
     ):
-        return onnxmltools.convert_keras(model, target_opset=opset)
+        tmpdir = tempfile.mkdtemp()
+        save_path = os.path.join(tmpdir, "temp_from_keras/")
 
+        tf.saved_model.save(model, save_path)
+        onnx_save = str(save_path)+'/last_tf2onnx_model.onnx'
+        try:
+            convertcmd = ['python', '-m', 'tf2onnx.convert', '--saved-model', save_path, '--output', onnx_save,
+                          '--opset', str(opset)]
+            subprocess.run(convertcmd)
+            logger.info('ONNX format converted successfully')
+            return onnx.load(onnx_save)
+        except Exception as e:
+            logger.error('Unable to convert to ONNX format, reason:')
+            logger.error(e)
+            return False
+
+    @staticmethod
+    def from_tensorflow(
+            saved_model_path: Path,
+            opset: int = DEFAULT_OPSET,
+    ):
+        tmpdir = tempfile.mkdtemp()
+        save_path = os.path.join(tmpdir, "temp_from_tensorflow/")
+        onnx_save = str(save_path)+'/tf_savedmodel.onnx'
+        try:
+            convertcmd = ['python', '-m', 'tf2onnx.convert', '--saved-model', saved_model_path, '--output', onnx_save,
+                          '--opset', str(opset)]
+            subprocess.run(convertcmd)
+            logger.info('ONNX format converted successfully')
+            return onnx.load(onnx_save)
+        except Exception as e:
+            logger.error('Unable to convert to ONNX format, reason:')
+            logger.error(e)
+            return False
     @staticmethod
     @_Wrapper.save
     def from_sklearn(

--- a/modelci/utils/trt_builder.py
+++ b/modelci/utils/trt_builder.py
@@ -48,7 +48,8 @@ def allocate_buffers(engine):
 # inputs and outputs are expected to be lists of HostDeviceMem objects.
 def do_inference(context, bindings, inputs, outputs, stream, batch_size=1):
     # Transfer input data to the GPU.
-    [cuda.memcpy_htod_async(inp.device, inp.host, stream) for inp in inputs]
+    for inp in inputs:
+        cuda.memcpy_htod_async(inp.device, inp.host, stream)
     # Run inference.
     context.execute_async(batch_size=batch_size, bindings=bindings, stream_handle=stream.handle)
     # Transfer predictions back from the GPU.

--- a/modelci/utils/trt_builder.py
+++ b/modelci/utils/trt_builder.py
@@ -53,7 +53,8 @@ def do_inference(context, bindings, inputs, outputs, stream, batch_size=1):
     # Run inference.
     context.execute_async(batch_size=batch_size, bindings=bindings, stream_handle=stream.handle)
     # Transfer predictions back from the GPU.
-    [cuda.memcpy_dtoh_async(out.host, out.device, stream) for out in outputs]
+    for out in outputs:
+        cuda.memcpy_dtoh_async(out.host, out.device, stream)
     # Synchronize the stream
     stream.synchronize()
     # Return only the host outputs.

--- a/modelci/utils/trt_builder.py
+++ b/modelci/utils/trt_builder.py
@@ -1,0 +1,59 @@
+import pycuda.autoinit
+
+import pycuda.driver as cuda
+import tensorrt as trt
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
+EXPLICIT_BATCH = 1 << (int)(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH)
+
+def GiB(val):
+    return val * 1 << 30
+# Simple helper data class that's a little nicer to use than a 2-tuple.
+class HostDeviceMem(object):
+    def __init__(self, host_mem, device_mem):
+        self.host = host_mem
+        self.device = device_mem
+
+    def __str__(self):
+        return "Host:\n" + str(self.host) + "\nDevice:\n" + str(self.device)
+
+    def __repr__(self):
+        return self.__str__()
+
+# Allocates all buffers required for an engine, i.e. host/device inputs/outputs.
+def allocate_buffers(engine):
+    inputs = []
+    outputs = []
+    bindings = []
+    stream = cuda.Stream()
+    for binding in engine:
+        size = trt.volume(engine.get_binding_shape(binding)) * engine.max_batch_size
+        dtype = trt.nptype(engine.get_binding_dtype(binding))
+        # Allocate host and device buffers
+        host_mem = cuda.pagelocked_empty(size, dtype)
+        device_mem = cuda.mem_alloc(host_mem.nbytes)
+        # Append the device buffer to device bindings.
+        bindings.append(int(device_mem))
+        # Append to the appropriate list.
+        if engine.binding_is_input(binding):
+            inputs.append(HostDeviceMem(host_mem, device_mem))
+        else:
+            outputs.append(HostDeviceMem(host_mem, device_mem))
+    return inputs, outputs, bindings, stream
+
+# This function is generalized for multiple inputs/outputs.
+# inputs and outputs are expected to be lists of HostDeviceMem objects.
+def do_inference(context, bindings, inputs, outputs, stream, batch_size=1):
+    # Transfer input data to the GPU.
+    [cuda.memcpy_htod_async(inp.device, inp.host, stream) for inp in inputs]
+    # Run inference.
+    context.execute_async(batch_size=batch_size, bindings=bindings, stream_handle=stream.handle)
+    # Transfer predictions back from the GPU.
+    [cuda.memcpy_dtoh_async(out.host, out.device, stream) for out in outputs]
+    # Synchronize the stream
+    stream.synchronize()
+    # Return only the host outputs.
+    return [out.host for out in outputs]

--- a/tests/test_tensorflow_conversion.py
+++ b/tests/test_tensorflow_conversion.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+import unittest
+
+import onnxruntime
+
+from modelci.utils import trt_builder
+import tensorflow as tf
+import numpy as np
+from modelci.hub.converter import convert
+import onnx
+import os
+import tempfile
+class TestTensorflowConverter(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        tmpdir = tempfile.mkdtemp()
+
+        file = tf.keras.utils.get_file(
+            "grace_hopper.jpg",
+            "https://storage.googleapis.com/download.tensorflow.org/example_images/grace_hopper.jpg")
+        img = tf.keras.preprocessing.image.load_img(file, target_size=[224, 224])
+        cls.x = tf.keras.preprocessing.image.img_to_array(img)
+        cls.x = tf.keras.applications.mobilenet.preprocess_input(
+            cls.x[tf.newaxis, ...])
+        cls.shape = [1,224,224,3]
+        labels_path = tf.keras.utils.get_file(
+            'ImageNetLabels.txt',
+            'https://storage.googleapis.com/download.tensorflow.org/data/ImageNetLabels.txt')
+        cls.imagenet_labels = np.array(open(labels_path).read().splitlines())
+        cls.tf_model = tf.keras.applications.MobileNet()
+        result_before_save = cls.tf_model(cls.x)
+        cls.mobilenet_save_path = os.path.join(tmpdir, "mobilenet/1/")
+        tf.saved_model.save(cls.tf_model, cls.mobilenet_save_path)
+
+        cls.decoded = cls.imagenet_labels[np.argsort(result_before_save)[0, ::-1][:5] + 1]
+
+    def test_tensorflow_to_onnx(self):
+        onnx_model = convert(self.mobilenet_save_path, 'tensorflow', 'onnx')
+        onnx.checker.check_model(onnx_model)
+        sess = onnxruntime.InferenceSession(onnx_model.SerializeToString())
+        input_name = sess.get_inputs()[0].name
+        output_name = sess.get_outputs()[0].name
+        res = np.array(sess.run([output_name], {input_name: self.x}))
+        onnxres = self.imagenet_labels[np.argsort(res)[0, ::-1][:5] + 1]
+        pred = onnxres[-1][-5:]
+        np.testing.assert_string_equal(str(pred[::-1]), str(self.decoded))
+
+
+
+    def test_tensorflow_to_trt(self):
+        engine = convert(self.mobilenet_save_path, 'tensorflow', 'trt', shape=self.shape)
+        inputs, outputs, bindings, stream = trt_builder.allocate_buffers(engine)
+
+        with engine.create_execution_context() as context:
+            imput_img = self.x.reshape(150528)
+            np.copyto(inputs[0].host, imput_img)
+            output = trt_builder.do_inference(context, bindings=bindings, inputs=inputs, outputs=outputs, stream=stream)
+            pred = self.imagenet_labels[np.argsort(output)[0,::-1][:5]+1]
+   
+        np.testing.assert_string_equal(str(pred), str(self.decoded))
+
+
+    if __name__ == '__main__':
+        unittest.main()


### PR DESCRIPTION
    1.to_trt.py:
        supported_framework add "tensorflow"
        add function--def from_tensorflow()
    2.to_onnx.py:
        add function--def from_tensorflow()
    3.add file--trt_builder.py to utils
    4.add file--test_tensorflow_conversion.py to tests

<!-- 
Closed which issue, if no, open one.
-->

Closes #

<!-- 
Thank you for contributing to ML-Model_CI!
-->

#### What has been done to verify that this works as intended?
A unit test has been made to verify the converting. 
#### Why is this the best possible solution? Were any other approaches considered?
The tf2onnx Api can effectively decouple the version iteration of the frameworks.
#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
Converting functions are relatively independent from each other, so the regression only causes the related converting command become invalid. 
#### Does this change require updates to documentation?
No
#### Before submitting this PR, please make sure you have:

- [x] run `python -m pytest tests/` and confirmed all checks still pass.
- [x] verified that any code or assets from external sources are properly credited.
