### PR TITLE
[MRG]Fix model retrieving from modelhub

### DIFF
--- a/modelci/types/models/mlmodel.py
+++ b/modelci/types/models/mlmodel.py
@@ -29,20 +29,20 @@ _fs = gridfs.GridFS(_db)
 class Weight(BaseModel):
     """TODO: Only works for MLModelIn"""
 
-    __slots__ = ('file', '_grid_out')
+    __slots__ = ('file', '_gridfs_out')
 
     __root__: Optional[PydanticObjectId]
 
     def __init__(self, __root__):
         if isinstance(__root__, Path):
             object.__setattr__(self, 'file', FilePath.validate(__root__))
-            object.__setattr__(self, '_grid_out', None)
+            object.__setattr__(self, '_gridfs_out', None)
             __root__ = None
 
         if isinstance(__root__, ObjectId):
             if _fs.exists(__root__):
                 object.__setattr__(self, 'file', None)
-                object.__setattr__(self, '_grid_out', _fs.get(__root__))
+                object.__setattr__(self, '_gridfs_out', _fs.get(__root__))
 
         super().__init__(__root__=__root__)
 
@@ -50,16 +50,16 @@ class Weight(BaseModel):
     def filename(self):
         if self.file:
             return self.file.name
-        elif self._grid_out:
-            return self._grid_out.filename
+        elif self._gridfs_out:
+            return self._gridfs_out.filename
         else:
             return ''
 
     def __bytes__(self):
         if self.file:
             return self.file.read_bytes()
-        elif self._grid_out:
-            return self._grid_out.read()
+        elif self._gridfs_out:
+            return self._gridfs_out.read()
         else:
             return b''
 

--- a/modelci/types/models/mlmodel.py
+++ b/modelci/types/models/mlmodel.py
@@ -29,20 +29,20 @@ _fs = gridfs.GridFS(_db)
 class Weight(BaseModel):
     """TODO: Only works for MLModelIn"""
 
-    __slots__ = ('file', 'grid_out')
+    __slots__ = ('file', '_grid_out')
 
     __root__: Optional[PydanticObjectId]
 
     def __init__(self, __root__):
         if isinstance(__root__, Path):
             object.__setattr__(self, 'file', FilePath.validate(__root__))
-            object.__setattr__(self, 'grid_out', None)
+            object.__setattr__(self, '_grid_out', None)
             __root__ = None
 
         if isinstance(__root__, ObjectId):
             if _fs.exists(__root__):
                 object.__setattr__(self, 'file', None)
-                object.__setattr__(self, 'grid_out', _fs.get(__root__))
+                object.__setattr__(self, '_grid_out', _fs.get(__root__))
 
         super().__init__(__root__=__root__)
 
@@ -50,16 +50,16 @@ class Weight(BaseModel):
     def filename(self):
         if self.file:
             return self.file.name
-        elif self.grid_out:
-            return self.grid_out.filename
+        elif self._grid_out:
+            return self._grid_out.filename
         else:
             return ''
 
     def __bytes__(self):
         if self.file:
             return self.file.read_bytes()
-        elif self.grid_out:
-            return self.grid_out.read()
+        elif self._grid_out:
+            return self._grid_out.read()
         else:
             return b''
 


### PR DESCRIPTION
<!-- 
Closed which issue, if no, open one.
-->

Closes #287

<!-- 
Thank you for contributing to ML-Model_CI!
-->

#### What has been done to verify that this works as intended?

Now model object can be retrieved and loaded by `saved_path`:

```python
model = get_by_id("6075bc371f60af4e3bf64bc4")
torch_model = torch.load(model.saved_path)
```

or by reading from GridFS

```python
  model = get_by_id("6075bc371f60af4e3bf64bc4")
  buffer = io.BytesIO(model.weight.__bytes__())
  torch_model = torch.load(buffer)
```


#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Does this change require updates to documentation?

#### Before submitting this PR, please make sure you have:

- [x] run `python -m pytest tests/` and confirmed all checks still pass.
- [x] verified that any code or assets from external sources are properly credited.
